### PR TITLE
Modifications to accomodate fuze_postgresql cookbook

### DIFF
--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -25,11 +25,7 @@ action :install do
     only_if { new_resource.setup_repo }
   end
 
-  case node['platform_family']
-  when 'debian'
-    package "postgresql-client-#{new_resource.version}"
-  when 'rhel', 'fedora', 'amazon'
-    ver = new_resource.version.delete('.')
-    package "postgresql#{ver}"
+  package "postgresql-client-#{new_resource.version}" do
+    only_if { platform_family?('debian') }
   end
 end

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -28,44 +28,44 @@ action :add do
   case node['platform_family']
 
   when 'rhel', 'fedora', 'amazon'
-    remote_file "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}" do
+    remote_file "/etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{pg_base_ver(new_resource.version)}" do
       source new_resource.yum_gpg_key_uri
     end
 
-    yum_repository "PostgreSQL #{new_resource.version}" do # ~FC005
-      repositoryid "pgdg#{new_resource.version}"
-      description "PostgreSQL.org #{new_resource.version}"
+    yum_repository "PostgreSQL #{pg_base_ver(new_resource.version)}" do # ~FC005
+      repositoryid "pgdg#{pg_base_ver(new_resource.version)}"
+      description "PostgreSQL.org #{pg_base_ver(new_resource.version)}"
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum')
       enabled     new_resource.enable_pgdg
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{pg_base_ver(new_resource.version)}"
     end
 
-    yum_repository "PostgreSQL #{new_resource.version} - source " do
-      repositoryid "pgdg#{new_resource.version}-source"
-      description "PostgreSQL.org #{new_resource.version} Source"
+    yum_repository "PostgreSQL #{pg_base_ver(new_resource.version)} - source " do
+      repositoryid "pgdg#{pg_base_ver(new_resource.version)}-source"
+      description "PostgreSQL.org #{pg_base_ver(new_resource.version)} Source"
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/srpms')
       enabled     new_resource.enable_pgdg_source
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{pg_base_ver(new_resource.version)}"
     end
 
-    yum_repository "PostgreSQL #{new_resource.version} - updates testing" do
-      repositoryid "pgdg#{new_resource.version}-updates-testing"
-      description "PostgreSQL.org #{new_resource.version} Updates Testing"
+    yum_repository "PostgreSQL #{pg_base_ver(new_resource.version)} - updates testing" do
+      repositoryid "pgdg#{pg_base_ver(new_resource.version)}-updates-testing"
+      description "PostgreSQL.org #{pg_base_ver(new_resource.version)} Updates Testing"
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/testing')
       enabled     new_resource.enable_pgdg_updates_testing
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{pg_base_ver(new_resource.version)}"
     end
 
-    yum_repository "PostgreSQL #{new_resource.version} - source - updates testing" do
-      repositoryid "pgdg#{new_resource.version}-source-updates-testing"
-      description "PostgreSQL.org #{new_resource.version} Source Updates Testing"
+    yum_repository "PostgreSQL #{pg_base_ver(new_resource.version)} - source - updates testing" do
+      repositoryid "pgdg#{pg_base_ver(new_resource.version)}-source-updates-testing"
+      description "PostgreSQL.org #{pg_base_ver(new_resource.version)} Source Updates Testing"
       baseurl     yum_repo_url('https://download.postgresql.org/pub/repos/yum/srpms/testing')
       enabled     new_resource.enable_pgdg_source_updates_testing
       gpgcheck    true
-      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{new_resource.version}"
+      gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PGDG-#{pg_base_ver(new_resource.version)}"
     end
 
   when 'debian'
@@ -75,7 +75,7 @@ action :add do
 
     apt_repository 'postgresql_org_repository' do
       uri          'https://download.postgresql.org/pub/repos/apt/'
-      components   ['main', new_resource.version.to_s]
+      components   ['main', pg_base_ver(new_resource.version).to_s]
       distribution "#{node['lsb']['codename']}-pgdg"
       key new_resource.apt_gpg_key_uri
       cache_rebuild true

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -22,6 +22,7 @@ property :createrole,         [true, false], default: false
 property :inherit,            [true, false], default: true
 property :replication,        [true, false], default: false
 property :login,              [true, false], default: true
+property :bypassrls,          [true, false], default: false
 property :password,           String
 property :encrypted_password, String
 property :valid_until,        String


### PR DESCRIPTION
### Description

- Fix to override data and conf directories to accommodate INF-9649
- Fix to enable postgres installations for versions 10, 11 etc.
- Ability to split conf dir from data dir

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable